### PR TITLE
Fix for flower blocks getting pulled into Forestry's Digger backpack

### DIFF
--- a/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
+++ b/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
@@ -82,7 +82,7 @@ public class ForestryPlugin {
         for (final ItemStack item : items)
             backpackItems[FORESTER].add(item);
 
-        items = ForestryModHelper.getForesterBackPackItems();
+        items = ForestryModHelper.getDiggerBackPackItems();
         for (final ItemStack item : items)
             backpackItems[DIGGER].add(item);
 


### PR DESCRIPTION
Changed one line in the Forestry compatibility module to add the list of dirt/stone blocks to the Digger's backpack rather than the list of Forester items. It fixes the "Why are flowers going into my Digger backpack?" problem.
