### PR TITLE
Fix saplings to work in Forestry Fermenter

### DIFF
--- a/extrabiomes/src/extrabiomes/handlers/BlockHandler.java
+++ b/extrabiomes/src/extrabiomes/handlers/BlockHandler.java
@@ -375,10 +375,19 @@ public abstract class BlockHandler {
                 .set(new ItemStack(block, 1, BlockCustomSapling.BlockType.FIR.metadata()));
         Element.SAPLING_REDWOOD.set(new ItemStack(block, 1, BlockCustomSapling.BlockType.REDWOOD
                 .metadata()));
-
+        
         final ItemStack stack = new ItemStack(block, 1, -1);
-        ForestryModHelper.registerSapling(stack);
         ForestryModHelper.addToForesterBackpack(stack);
+        
+        // The fermenter checks the damage value when deciding if the item can be fermented
+        // requiring each type to be registered separately
+        ForestryModHelper.registerSapling(Element.SAPLING_ACACIA.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_AUTUMN_BROWN.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_AUTUMN_ORANGE.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_AUTUMN_PURPLE.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_AUTUMN_YELLOW.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_FIR.get());
+        ForestryModHelper.registerSapling(Element.SAPLING_REDWOOD.get());
 
         // all but redwood
         final Element[] forestrySaplings = { Element.SAPLING_ACACIA, Element.SAPLING_AUTUMN_BROWN,

--- a/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
+++ b/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
@@ -51,7 +51,7 @@ public class ForestryPlugin {
 
     /**
      * public void addRecipe(ItemStack resource, int fermentationValue,
-     * float modifier, LiquidStack output, LiquisStack liquid);
+     * float modifier, LiquidStack output, LiquidStack liquid);
      */
     private Optional<Method>        fermenterAddRecipe = Optional.absent();
 
@@ -191,6 +191,7 @@ public class ForestryPlugin {
             cls = Class.forName("forestry.api.recipes.IFermenterManager");
             fermenterAddRecipe = Optional.fromNullable(cls.getMethod("addRecipe", ItemStack.class,
                     int.class, float.class, LiquidStack.class, LiquidStack.class));
+            
             cls = Class.forName("forestry.api.recipes.ICarpenterManager");
             carpenterAddRecipe = Optional.fromNullable(cls.getMethod("addRecipe", int.class,
                     LiquidStack.class, ItemStack.class, ItemStack.class, Object[].class));


### PR DESCRIPTION
The fermenter appears to check the damage value of items against the recipe when deciding if thy can be fermented, requiring that a separate recipe be added for each sapling type.
