### PR TITLE
Added support for saplings in new Forestry farms

### DIFF
--- a/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
+++ b/extrabiomes/src/extrabiomes/module/amica/forestry/ForestryPlugin.java
@@ -22,6 +22,8 @@ import net.minecraftforge.liquids.LiquidStack;
 
 import com.google.common.base.Optional;
 
+import cpw.mods.fml.common.event.FMLInterModComms;
+
 import extrabiomes.Extrabiomes;
 import extrabiomes.api.PluginEvent;
 import extrabiomes.api.Stuff;
@@ -129,6 +131,9 @@ public class ForestryPlugin {
             BlockCustomSapling.setForestrySoilID(soil.get().itemID);
         }
         arborealCrops.add(new CropProviderSapling());
+        
+        for(ItemStack sapling : ForestryModHelper.getSaplings())
+        	FMLInterModComms.sendMessage("Forestry", "add-farmable-sapling", String.format("farmArboreal@%s.%s", sapling.itemID, sapling.getItemDamage()));
     }
 
     private LiquidStack getLiquidStack(String name) throws Exception {


### PR DESCRIPTION
No API required, uses FML InterModComms to add generic saplings to the farms.

Note: This will not break with the current FML or the current Forestry, but it will only have an effect after Forestry 2.0.0.4 is released and after a tiny bug in FML is fixed. Currently FML's polling for IMC messages after startup is broken.
