### PR TITLE
NEI Compatibility Fixes / Standardization

### DIFF
--- a/common/extrabiomes/blocks/BlockAutumnLeaves.java
+++ b/common/extrabiomes/blocks/BlockAutumnLeaves.java
@@ -180,14 +180,16 @@ public class BlockAutumnLeaves extends BlockLeavesBase implements IShearable {
     @Override
     public Icon getIcon(int side, int metadata) {
         metadata = unmarkedMetadata(metadata);
-        if (metadata > 4) metadata = 4;
+        
+        // This check should be unneeded as unmarkedMetadata return a value between 0 and 3.
+        if (metadata < 0 || metadata > 4) metadata = 0;
             return textures[unmarkedMetadata(metadata) * 2 + (!isOpaqueCube() ? 0 : 1)];
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType blockType : BlockType.values())
+        for (final BlockType blockType : BlockType.values())
             itemList.add(new ItemStack(this, 1, blockType.metadata()));
     }
 

--- a/common/extrabiomes/blocks/BlockCustomFlower.java
+++ b/common/extrabiomes/blocks/BlockCustomFlower.java
@@ -168,7 +168,7 @@ public class BlockCustomFlower extends Block implements IPlantable {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType type : BlockType.values())
+        for (final BlockType type : BlockType.values())
             itemList.add(new ItemStack(this, 1, type.metadata()));
     }
 

--- a/common/extrabiomes/blocks/BlockCustomSapling.java
+++ b/common/extrabiomes/blocks/BlockCustomSapling.java
@@ -115,14 +115,16 @@ public class BlockCustomSapling extends BlockFlower {
     @Override
     public Icon getIcon(int side, int metadata) {
         metadata = unmarkedMetadata(metadata);
-        //if (metadata > 6) metadata = 0;
+        
+        // unmarkedMetadata has the potential to return a value between 0 and 7, since only 0 to 6 are valid we need to check validity.
+        if (metadata < 0 || metadata > 6) metadata = 0;
         return textures[metadata];
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType blockType : BlockType.values())
+    	for (final BlockType blockType : BlockType.values())
             itemList.add(new ItemStack(this, 1, blockType.metadata()));
     }
 

--- a/common/extrabiomes/blocks/BlockCustomTallGrass.java
+++ b/common/extrabiomes/blocks/BlockCustomTallGrass.java
@@ -43,7 +43,7 @@ public class BlockCustomTallGrass extends BlockFlower implements IShearable {
         }
     }
     
-    private Icon[] textures = {null, null, null, null, null, null, null, null};
+    private Icon[] textures = {null, null, null, null, null};
 
     public BlockCustomTallGrass(int id, int index, Material material) {
         super(id, material);
@@ -99,14 +99,15 @@ public class BlockCustomTallGrass extends BlockFlower implements IShearable {
 
     @Override
     public Icon getIcon(int side, int metadata) {
-        if (metadata > 4) metadata = 4;
+    	// Ensure that the metadata stays in proper range and we return a valid texture
+        if (metadata < 0 || metadata > 4) metadata = 0;
         return textures[metadata];
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType type : BlockType.values())
+        for (final BlockType type : BlockType.values())
             itemList.add(new ItemStack(this, 1, type.metadata()));
     }
 

--- a/common/extrabiomes/blocks/BlockGreenLeaves.java
+++ b/common/extrabiomes/blocks/BlockGreenLeaves.java
@@ -208,7 +208,9 @@ public class BlockGreenLeaves extends BlockLeavesBase implements IShearable {
     @Override
     public Icon getIcon(int side, int metadata){
         metadata = unmarkedMetadata(metadata);
-        if (metadata > 2) metadata = 0;
+        
+        // unmarkedMetadata has the potential to return a value between 0 and 3, since only 0 to 2 are valid we need to check validity.
+        if (metadata < 0 || metadata > 2) metadata = 0;
         return textures[unmarkedMetadata(metadata) * 2 + (!isOpaqueCube() ? 0 : 1)];
     }
 
@@ -230,7 +232,7 @@ public class BlockGreenLeaves extends BlockLeavesBase implements IShearable {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType blockType : BlockType.values())
+        for (final BlockType blockType : BlockType.values())
             itemList.add(new ItemStack(this, 1, blockType.metadata()));
     }
 

--- a/common/extrabiomes/blocks/BlockRedRock.java
+++ b/common/extrabiomes/blocks/BlockRedRock.java
@@ -89,7 +89,7 @@ public class BlockRedRock extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public void getSubBlocks(int id, CreativeTabs tab, List itemList) {
-        if (tab == Extrabiomes.tabsEBXL) for (final BlockType blockType : BlockType.values())
+        for (final BlockType blockType : BlockType.values())
             itemList.add(new ItemStack(this, 1, blockType.metadata()));
     }
 }

--- a/common/extrabiomes/module/fabrica/block/BlockCustomWood.java
+++ b/common/extrabiomes/module/fabrica/block/BlockCustomWood.java
@@ -55,16 +55,15 @@ public class BlockCustomWood extends BlockWood {
     }
 
 	@Override
-	public Icon getIcon(int side, int metadata)
-	{
+	public Icon getIcon(int side, int metadata)	{
+		// Ensure that the texture id is in range
+		if (metadata < 0 || metadata > 2) metadata = 0;
 		return textures[metadata];
 	}
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void getSubBlocks(int blockID,
-			CreativeTabs par2CreativeTabs, List list)
-	{
+	public void getSubBlocks(int blockID, CreativeTabs par2CreativeTabs, List list) {
 		for (final BlockType type : BlockType.values())
 			list.add(new ItemStack(blockID, 1, type.metadata()));
 	}


### PR DESCRIPTION
In trying to track down why NEI was showing an invalid sapling (subblock
7) in my last patch, the naive fix that I put in allowed newer versions
of NEI to attempt to access a out of bounds texture due. I think I have
finally nailed it down with this patch.

From what I was able to track down some of the blocks, but not all were
only returning the subblock info if it was requested from the EbXL
creative tab, so when NEI or anything else asked for the valid subblocks
it was not returning anything meaning that NEI had to try all possible
subblocks. The patch will definitely need someone else's eyes on it, but
I checked my changes against vanilla blocks and a couple other mods to
see how they did things to make sure I was going along the same line.

(I manged to get in about 1 hour of play testing doing quite a bit of crafting and did not have anything showing up in the logs from us using this commit., but it still needs review in my opinion.)
