### PR TITLE
Specify english locale for toupper/tolower when we want english capitalization.

### DIFF
--- a/common/extrabiomes/Extrabiomes.java
+++ b/common/extrabiomes/Extrabiomes.java
@@ -61,7 +61,7 @@ public class Extrabiomes
     
     public static final CreativeTabs  tabsEBXL     = new CreativeTab("extrabiomesTab");
     
-    public static final String        TEXTURE_PATH = Reference.MOD_ID.toLowerCase() + ":";
+    public static final String        TEXTURE_PATH = Reference.MOD_ID.toLowerCase(Locale.ENGLISH) + ":";
     
     private static Optional<EventBus> initBus      = Optional.of(new EventBus());
     

--- a/common/extrabiomes/handlers/BiomeHandler.java
+++ b/common/extrabiomes/handlers/BiomeHandler.java
@@ -101,7 +101,7 @@ public enum BiomeHandler
     @ForgeSubscribe
     public void handleBiomeIDRequestsFromAPI(GetBiomeIDEvent event)
     {
-        final Optional<BiomeSettings> settings = Optional.fromNullable(BiomeSettings.valueOf(event.targetBiome.toUpperCase()));
+        final Optional<BiomeSettings> settings = Optional.fromNullable(BiomeSettings.valueOf(event.targetBiome.toUpperCase(Locale.ENGLISH)));
         if (settings.isPresent())
         {
             event.biomeID = settings.get().getID();

--- a/common/extrabiomes/items/ItemCustomGreenLeaves.java
+++ b/common/extrabiomes/items/ItemCustomGreenLeaves.java
@@ -24,7 +24,7 @@ public class ItemCustomGreenLeaves extends ItemCustomLeaves
         //if (metadata > 2) metadata = 0;
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockGreenLeaves.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockGreenLeaves.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/items/ItemCustomLeaves.java
+++ b/common/extrabiomes/items/ItemCustomLeaves.java
@@ -28,7 +28,7 @@ public class ItemCustomLeaves extends MultiItemBlock
             metadata = 3;
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockAutumnLeaves.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockAutumnLeaves.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
     private static final int METADATA_USERPLACEDBIT = 0x4;

--- a/common/extrabiomes/items/ItemCustomMiniLog.java
+++ b/common/extrabiomes/items/ItemCustomMiniLog.java
@@ -28,7 +28,7 @@ public class ItemCustomMiniLog extends MultiItemBlock
             metadata = 0;
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockMiniLog.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockMiniLog.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
     private static final int METADATA_USERPLACEDBIT = 0x4;

--- a/common/extrabiomes/items/ItemCustomMoreLeaves.java
+++ b/common/extrabiomes/items/ItemCustomMoreLeaves.java
@@ -18,7 +18,7 @@ public class ItemCustomMoreLeaves extends ItemCustomLeaves
         //if (metadata > 2) metadata = 0;
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockMoreLeaves.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockMoreLeaves.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/items/ItemCustomNewLeaves.java
+++ b/common/extrabiomes/items/ItemCustomNewLeaves.java
@@ -18,7 +18,7 @@ public class ItemCustomNewLeaves extends ItemCustomLeaves
         //if (metadata > 2) metadata = 0;
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockNewLeaves.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockNewLeaves.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/items/ItemNewSapling.java
+++ b/common/extrabiomes/items/ItemNewSapling.java
@@ -25,7 +25,7 @@ public class ItemNewSapling extends MultiItemBlock
         int metadata = unmarkedMetadata(itemstack.getItemDamage());
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockNewSapling.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockNewSapling.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/items/ItemSapling.java
+++ b/common/extrabiomes/items/ItemSapling.java
@@ -25,7 +25,7 @@ public class ItemSapling extends MultiItemBlock
         int metadata = unmarkedMetadata(itemstack.getItemDamage());
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
-        return super.getUnlocalizedName() + "." + BlockCustomSapling.BlockType.values()[metadata].toString().toLowerCase();
+        return super.getUnlocalizedName() + "." + BlockCustomSapling.BlockType.values()[metadata].toString().toLowerCase(Locale.ENGLISH);
         //return super.getUnlocalizedName(itemstack);
     }
 }

--- a/common/extrabiomes/lib/BiomeSettings.java
+++ b/common/extrabiomes/lib/BiomeSettings.java
@@ -186,7 +186,7 @@ public enum BiomeSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/lib/BlockSettings.java
+++ b/common/extrabiomes/lib/BlockSettings.java
@@ -185,7 +185,7 @@ public enum BlockSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/lib/DecorationSettings.java
+++ b/common/extrabiomes/lib/DecorationSettings.java
@@ -154,7 +154,7 @@ public enum DecorationSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/lib/ItemSettings.java
+++ b/common/extrabiomes/lib/ItemSettings.java
@@ -37,7 +37,7 @@ public enum ItemSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/lib/ModuleControlSettings.java
+++ b/common/extrabiomes/lib/ModuleControlSettings.java
@@ -63,7 +63,7 @@ public enum ModuleControlSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
     
 }

--- a/common/extrabiomes/lib/SaplingSettings.java
+++ b/common/extrabiomes/lib/SaplingSettings.java
@@ -38,6 +38,6 @@ public enum SaplingSettings
     @Override
     public String toString()
     {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(Locale.ENGLISH);
     }
 }


### PR DESCRIPTION
When locale is unspecified, turkish users will experience turkish capitalization, which is slightly different and causes problems:  http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug
