### PR TITLE
Prevent ProjectE crash from saplings

### DIFF
--- a/src/main/java/extrabiomes/items/ItemNewSapling.java
+++ b/src/main/java/extrabiomes/items/ItemNewSapling.java
@@ -30,6 +30,11 @@ public class ItemNewSapling extends MultiItemBlock
         int metadata = unmarkedMetadata(itemstack.getItemDamage());
         itemstack = itemstack.copy();
         itemstack.setItemDamage(metadata);
+        
+        if(BlockNewSapling.BlockType.values()[metadata & METADATA_BITMASK] == null) {
+          return null;
+        }
+        
         return super.getUnlocalizedName() + "." + BlockNewSapling.BlockType.values()[metadata & METADATA_BITMASK].toString().toLowerCase(Locale.ENGLISH);
     }
     

--- a/version/gradle.properties
+++ b/version/gradle.properties
@@ -3,4 +3,4 @@ mcversion=1.7.10
 forgeversion=10.13.2.1230
 version_major=3
 version_series=16
-version_revision=1
+version_revision=2


### PR DESCRIPTION
ProjectE brute force checks' are making assumptions about metadata and
causing issues with us.

The new sapling block assumes that using the bitbask will be enough and
that no one will be calling with metadata that is completely invalid. If
the block type value is invalid we won't try to convert it to a string.

Also bump revision.